### PR TITLE
Fixes php 7 issue

### DIFF
--- a/lib/Essence/Log/Logger/Null.php
+++ b/lib/Essence/Log/Logger/Null.php
@@ -17,7 +17,7 @@ use Essence\Log\Logger;
  *	@package Essence.Log.Logger
  */
 
-class Null implements Logger {
+class NullClass implements Logger {
 
 	/**
 	 *	{@inheritDoc}


### PR DESCRIPTION
Cannot use 'Null' as class name as it is reserved